### PR TITLE
Add scala 2.11 to cross build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,8 @@ crossScalaVersions in ThisBuild := Seq("2.9.2", "2.10.0", "2.11.0")
 
 libraryDependencies ++= {
   Seq(
+  	"org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.1",
+  	"org.scala-lang.modules" %% "scala-xml" % "1.0.2",
     "org.scalatest" %% "scalatest" % "2.1.6" % "test" withSources(),
     "junit" % "junit" % "4.8.2" % "test"
   )

--- a/build.sbt
+++ b/build.sbt
@@ -21,13 +21,18 @@ version := "0.2.7-SNAPSHOT"
 
 crossScalaVersions in ThisBuild := Seq("2.9.2", "2.10.0", "2.11.0")
 
-libraryDependencies ++= {
-  Seq(
-  	"org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.1",
-  	"org.scala-lang.modules" %% "scala-xml" % "1.0.2",
-    "org.scalatest" %% "scalatest" % "2.1.6" % "test" withSources(),
-    "junit" % "junit" % "4.8.2" % "test"
-  )
+libraryDependencies <++= (scalaVersion) { v:String =>
+	if (v.startsWith("2.11"))
+		Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.1",
+		"org.scala-lang.modules" %% "scala-xml" % "1.0.2",
+		"org.scalatest" %% "scalatest" % "2.1.6" % "test" withSources(),
+		"junit" % "junit" % "4.8.2" % "test")
+	else if (v.startsWith("2.10"))
+		Seq("org.scalatest" %% "scalatest" % "2.1.6" % "test" withSources(),
+		"junit" % "junit" % "4.8.2" % "test")
+	else
+		Seq("org.scalatest" %% "scalatest" % "1.8" % "test" withSources(),
+		"junit" % "junit" % "4.8.2" % "test")
 }
 
 //TODO: reactivate once junit-XML listener is on maven central

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ name := "actuarius"
 
 description := "Actuarius is a Markdown Processor written in Scala using parser combinators."
 
-scalaVersion := "2.10.0"
+scalaVersion := "2.11.0"
 
 scalacOptions += "-deprecation"
 
@@ -19,7 +19,7 @@ resolvers += "Scala" at "https://oss.sonatype.org/content/groups/scala-tools/"
 
 version := "0.2.7-SNAPSHOT"
 
-crossScalaVersions in ThisBuild := Seq("2.9.2", "2.10.0")
+crossScalaVersions in ThisBuild := Seq("2.9.2", "2.10.0", "2.11.0")
 
 libraryDependencies ++= {
   Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ crossScalaVersions in ThisBuild := Seq("2.9.2", "2.10.0")
 
 libraryDependencies ++= {
   Seq(
-    "org.scalatest" %% "scalatest" % "1.8" % "test" withSources(),
+    "org.scalatest" %% "scalatest" % "2.1.6" % "test" withSources(),
     "junit" % "junit" % "4.8.2" % "test"
   )
 }

--- a/src/test/scala/eu/henkelmann/actuarius/LineTokenizerTest.scala
+++ b/src/test/scala/eu/henkelmann/actuarius/LineTokenizerTest.scala
@@ -9,23 +9,25 @@ import org.scalatest.junit.JUnitRunner
  * Tests the Line Tokenizer that prepares input for parsing.
  */
 @RunWith(classOf[JUnitRunner])
-class LineTokenizerTest extends LineTokenizer with FlatSpec with ShouldMatchers{
+class LineTokenizerTest extends FlatSpec with ShouldMatchers{
 
+	val lineTokenizer = new LineTokenizer
+  
     "The LineTokenizer" should "split input lines correctly" in {
-        splitLines("line1\nline2\n") should equal (List("line1", "line2"))
-        splitLines("line1\nline2 no nl") should equal (List("line1", "line2 no nl"))
-        splitLines("test1\n\ntest2\n") should equal (List("test1", "", "test2"))
-        splitLines("test1\n\ntest2\n\n") should equal (List("test1", "", "test2"))
-        splitLines("\n\n") should equal (Nil)
-        splitLines("\n") should equal (Nil)
-        splitLines("") should equal (List(""))
+        lineTokenizer.splitLines("line1\nline2\n") should equal (List("line1", "line2"))
+        lineTokenizer.splitLines("line1\nline2 no nl") should equal (List("line1", "line2 no nl"))
+        lineTokenizer.splitLines("test1\n\ntest2\n") should equal (List("test1", "", "test2"))
+        lineTokenizer.splitLines("test1\n\ntest2\n\n") should equal (List("test1", "", "test2"))
+        lineTokenizer.splitLines("\n\n") should equal (Nil)
+        lineTokenizer.splitLines("\n") should equal (Nil)
+        lineTokenizer.splitLines("") should equal (List(""))
     }
 
     it should "preprocess the input correctly" in {
-        tokenize("[foo]: http://example.com/  \"Optional Title Here\"") should equal(
+        lineTokenizer.tokenize("[foo]: http://example.com/  \"Optional Title Here\"") should equal(
             (new MarkdownLineReader(List(), Map( "foo"->new LinkDefinition("foo", "http://example.com/", Some("Optional Title Here")) )) ) )
 
-        tokenize(
+        lineTokenizer.tokenize(
 """[Baz]:    http://foo.bar
 'Title next line'
 some text
@@ -49,8 +51,8 @@ new OtherLine("more text")
 
     it should "parse different line types" in {
         def p(line:String) = {
-            lineToken(new LineReader(Seq(line))) match {
-                case Success(result, _) => result
+            lineTokenizer.lineToken(new LineReader(Seq(line))) match {
+                case lineTokenizer.Success(result, _) => result
             }
         }
         p("a line")          should equal (new OtherLine("a line"))


### PR DESCRIPTION
Added cross build support to 2.11. To do so, I had to upgrade scalatest (to 2.1.6) and add xml and parser combinators modules when building against 2.11.

The upgrade of scalatest resulted in 25 warnings. I didn't fix them to keep this pull request small, but if you want, I can issue another pull request fixing them.
