### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##About Actuarius##
+## About Actuarius ##
 Actuarius is a Markdown Processor written in Scala using parser combinators. 
 
 The project homepage can be found on github: https://github.com/chenkelmann/actuarius
@@ -12,20 +12,20 @@ To try Actuarius out, you can use the web dingus on my home page: http://henkelm
 
 To get Actuarius, you can either check out the source from github, use maven/sbt to add it as a dependency (see below) or download the binary jar, javadoc jar or source jar directly from my maven repo at http://maven.henkelmann.eu/eu/henkelmann/
 
-##License##
+## License ##
 Actuarius is licensed under the 3-clause BSD license. For details see the `LICENSE` file that comes with the source.
 
-##Compatibility##
+## Compatibility ##
 Actuarius tries to stay as close to the original Markdown syntax definition as possible. There were however some quirks in the original Markdown I did not like. I wrote Actuarius as a Markdown processor for my homebrew blog engine, so I took the liberty to diverge slightly from the way the original Markdown works. The details are explained [in the respective article in the Actuarius Wiki](https://github.com/chenkelmann/actuarius/wiki/Differences-Between-Actuarius-And-Standard-Markdown)
 
-##Maven##
+## Maven ##
 The group id is `eu.henkelmann`, the artifact id is `actuarius_[scala-version]`, e.g.`actuarius_2.10.0`. The current stable version is 0.2.6. The current development version is 0.2.7-SNAPSHOT.
 Actuarius is available from the [Sonatype OSS repository](https://oss.sonatype.org), so you should not have to add any repository definitions.
 
 Starting with version 0.2.5 there are builds for Scala 2.9.2 and 2.10.0. These versions are also available from maven central.
 (How I hate Scala's binary incompatibilities…)
 
-##sbt##
+## sbt ##
 To add the lib to your project, add the following to your `.sbt` file if you are using scala 2.10.x:
 
     libraryDependencies += "eu.henkelmann" % "actuarius_2.10.0" % "0.2.6"
@@ -37,7 +37,7 @@ or, for 2.9.x compatibility:
     
 Currently, Actuarius itself is built using sbt 0.11.x
 
-##Version History##
+## Version History ##
 
 ### 0.2.6
 * fixed bug in html / xml element parsing: attributes surrounded by ticks (`'`) are now also parsed as well as attributes surrounded by quotes (`"`)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
